### PR TITLE
Split code between library and binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0 - 2026-03-18
+
+- Move all module declarations, orchestration logic, and progress writer infrastructure from `main.rs` to `lib.rs`, reducing the binary entry point to a thin ~20-line wrapper that only handles tracing setup and runtime construction.
+
 ## 1.0.1 - 2026-03-13
 
 - Handle episodes without subtitles gracefully: the `subtitles` field in the API response is now optional. When subtitles are unavailable and the user has not passed `--skip-subtitles`, a clear error is returned naming the episode and suggesting the flag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cat_show_downloader"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,15 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/mcamara/3cat_show_downloader"
-version = "1.0.1"
+version = "1.1.0"
 
+[[bin]]
+name = "cat_show_downloader"
+path = "src/main.rs"
+
+[lib]
+name = "cat_show_downloader"
+path = "src/lib.rs"
 
 [lints.rust]
 missing_docs = "warn"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,35 @@
+//! Command-line argument definitions for the 3cat media downloader.
+
+use clap::Parser;
+
+/// Command-line arguments for the 3cat media downloader.
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct CatShowDownloaderArgs {
+    /// Slug of the TV show or movie (e.g. "bola-de-drac" from https://www.3cat.cat/3cat/bola-de-drac/)
+    pub(crate) slug: String,
+
+    /// Directory to save the downloaded files
+    #[arg(short, long)]
+    pub(crate) directory: String,
+
+    /// Episode number to start from (ignored for movies)
+    #[arg(short, long, default_value_t = 1)]
+    pub(crate) start_from_episode: i32,
+
+    /// Number of files to download concurrently (1-10)
+    #[arg(short, long, default_value_t = 2, value_parser = clap::value_parser!(u8).range(1..=10))]
+    pub(crate) concurrent_downloads: u8,
+
+    /// Skip downloading subtitles
+    #[arg(long, default_value_t = false)]
+    pub(crate) skip_subtitles: bool,
+
+    /// Fix (clean) previously downloaded subtitle files in the directory
+    #[arg(short, long, default_value_t = false)]
+    pub(crate) fix_existing_subtitles: bool,
+
+    /// Clean and embed existing subtitle files into their matching video files (requires ffmpeg)
+    #[arg(long, default_value_t = false)]
+    pub(crate) embed_existing_subtitles: bool,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,10 @@ pub async fn run(args: CatShowDownloaderArgs, multi_progress: MultiProgress) -> 
         );
     }
 
+    if args.fix_existing_subtitles {
+        subtitle_cleaner::fix_existing_subtitles(&args.directory)?;
+    }
+
     let ffmpeg_available = ffmpeg::is_available().await;
 
     if args.embed_existing_subtitles {
@@ -121,10 +125,6 @@ pub async fn run(args: CatShowDownloaderArgs, multi_progress: MultiProgress) -> 
 
     let http_client = http_client::http_client();
     let media = media_resolver::get_media_id(&args.slug).await?;
-
-    if args.fix_existing_subtitles {
-        subtitle_cleaner::fix_existing_subtitles(&args.directory)?;
-    }
 
     let subtitle_mode = if args.skip_subtitles {
         SubtitleMode::Skip

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,13 @@ impl Drop for MultiProgressLineWriter {
 #[allow(clippy::let_and_return)] // Binding needed to satisfy Rust 2024 tail-expression drop order rules
 #[instrument(skip_all)]
 pub async fn run(args: CatShowDownloaderArgs, multi_progress: MultiProgress) -> anyhow::Result<()> {
+    if args.start_from_episode < 1 {
+        anyhow::bail!(
+            "start_from_episode must be at least 1, got {}",
+            args.start_from_episode
+        );
+    }
+
     let ffmpeg_available = ffmpeg::is_available().await;
 
     if args.embed_existing_subtitles {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,146 @@
+//! Library crate for downloading TV shows and movies from 3cat.cat.
+//!
+//! This crate provides the core logic for resolving media slugs, fetching
+//! episode metadata, downloading video and subtitle files, and optionally
+//! embedding subtitles via ffmpeg. The binary crate (`main.rs`) is a thin
+//! entry point that sets up tracing, builds the Tokio runtime, and delegates
+//! to [`run()`].
+
+mod api_structs;
+mod cli;
+mod downloader;
+mod error;
+mod ffmpeg;
+mod http_client;
+mod media_resolver;
+mod models;
+mod movie;
+mod scheduler;
+pub mod subtitle_cleaner;
+mod tv_show;
+
+use std::io;
+use std::sync::Arc;
+
+use indicatif::MultiProgress;
+use tracing::{info, instrument, warn};
+use tracing_subscriber::fmt::MakeWriter;
+
+pub use crate::cli::CatShowDownloaderArgs;
+use crate::media_resolver::MediaType;
+use crate::models::{DownloadParams, SubtitleMode};
+
+/// A [`MakeWriter`] implementation that routes output through [`MultiProgress::println`].
+///
+/// This ensures that tracing log lines are printed above the progress bars
+/// without disrupting their rendering.
+#[derive(Clone, Debug)]
+pub struct MultiProgressWriter {
+    mp: MultiProgress,
+}
+
+impl MultiProgressWriter {
+    /// Creates a new writer that routes output through the given [`MultiProgress`].
+    pub fn new(mp: MultiProgress) -> Self {
+        Self { mp }
+    }
+}
+
+/// Per-event writer that buffers bytes and flushes complete lines via [`MultiProgress::println`].
+///
+/// This type is an implementation detail of [`MultiProgressWriter`] and should
+/// not be constructed directly.
+#[derive(Debug)]
+pub struct MultiProgressLineWriter {
+    mp: MultiProgress,
+    buf: Vec<u8>,
+}
+
+impl<'a> MakeWriter<'a> for MultiProgressWriter {
+    type Writer = MultiProgressLineWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        MultiProgressLineWriter {
+            mp: self.mp.clone(),
+            buf: Vec::new(),
+        }
+    }
+}
+
+impl io::Write for MultiProgressLineWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if !self.buf.is_empty() {
+            let line = String::from_utf8_lossy(&self.buf).trim_end().to_string();
+            self.mp.println(&line)?;
+            self.buf.clear();
+        }
+        Ok(())
+    }
+}
+
+impl Drop for MultiProgressLineWriter {
+    fn drop(&mut self) {
+        let _ = io::Write::flush(self);
+    }
+}
+
+/// Runs the main application logic.
+///
+/// Resolves the provided slug as a TV show or movie, determines subtitle
+/// handling mode, and dispatches the appropriate download workflow.
+///
+/// # Errors
+///
+/// Returns an error if media resolution, subtitle processing, or downloading
+/// fails.
+#[allow(clippy::let_and_return)] // Binding needed to satisfy Rust 2024 tail-expression drop order rules
+#[instrument(skip_all)]
+pub async fn run(args: CatShowDownloaderArgs, multi_progress: MultiProgress) -> anyhow::Result<()> {
+    let ffmpeg_available = ffmpeg::is_available().await;
+
+    if args.embed_existing_subtitles {
+        if !ffmpeg_available {
+            anyhow::bail!(
+                "--embed-existing-subtitles requires ffmpeg, but ffmpeg was not found on PATH"
+            );
+        }
+        ffmpeg::embed_existing_subtitles(&args.directory).await?;
+    }
+
+    let http_client = http_client::http_client();
+    let media = media_resolver::get_media_id(&args.slug).await?;
+
+    if args.fix_existing_subtitles {
+        subtitle_cleaner::fix_existing_subtitles(&args.directory)?;
+    }
+
+    let subtitle_mode = if args.skip_subtitles {
+        SubtitleMode::Skip
+    } else if ffmpeg_available {
+        info!("ffmpeg detected, subtitles will be embedded into video files");
+        SubtitleMode::Embed
+    } else {
+        warn!("ffmpeg not found, subtitles will be downloaded as separate .vtt files");
+        SubtitleMode::Download
+    };
+
+    let params = DownloadParams {
+        http_client,
+        subtitle_mode,
+        concurrent_downloads: args.concurrent_downloads,
+        multi_progress,
+        directory: Arc::from(args.directory.as_str()),
+    };
+
+    let result = match media {
+        MediaType::TvShow(id) => tv_show::download(id, args.start_from_episode, &params).await,
+        MediaType::Movie { id, slug } => movie::download(id, &slug, &params).await,
+    };
+
+    result
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,108 +1,8 @@
-//! CLI tool to download TV shows and movies from 3cat.cat.
+//! CLI entry point for the 3cat media downloader.
 
-mod api_structs;
-mod downloader;
-mod error;
-mod ffmpeg;
-mod http_client;
-mod media_resolver;
-mod models;
-mod movie;
-mod scheduler;
-pub mod subtitle_cleaner;
-mod tv_show;
-
-use std::io;
-use std::sync::Arc;
-
+use cat_show_downloader::{CatShowDownloaderArgs, MultiProgressWriter, run};
 use clap::Parser;
 use indicatif::MultiProgress;
-use tracing::{info, instrument, warn};
-use tracing_subscriber::fmt::MakeWriter;
-
-use crate::media_resolver::MediaType;
-use crate::models::{DownloadParams, SubtitleMode};
-
-/// Command-line arguments for the 3cat media downloader.
-#[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
-struct Args {
-    /// Slug of the TV show or movie (e.g. "bola-de-drac" from https://www.3cat.cat/3cat/bola-de-drac/)
-    slug: String,
-
-    /// Directory to save the downloaded files
-    #[arg(short, long)]
-    directory: String,
-
-    /// Episode number to start from (ignored for movies)
-    #[arg(short, long, default_value_t = 1)]
-    start_from_episode: i32,
-
-    /// Number of files to download concurrently (1-10)
-    #[arg(short, long, default_value_t = 2, value_parser = clap::value_parser!(u8).range(1..=10))]
-    concurrent_downloads: u8,
-
-    /// Skip downloading subtitles
-    #[arg(long, default_value_t = false)]
-    skip_subtitles: bool,
-
-    /// Fix (clean) previously downloaded subtitle files in the directory
-    #[arg(short, long, default_value_t = false)]
-    fix_existing_subtitles: bool,
-
-    /// Clean and embed existing subtitle files into their matching video files (requires ffmpeg)
-    #[arg(long, default_value_t = false)]
-    embed_existing_subtitles: bool,
-}
-
-/// A [`MakeWriter`] implementation that routes output through [`MultiProgress::println`].
-///
-/// This ensures that tracing log lines are printed above the progress bars
-/// without disrupting their rendering.
-#[derive(Clone, Debug)]
-struct MultiProgressWriter {
-    mp: MultiProgress,
-}
-
-/// Per-event writer that buffers bytes and flushes complete lines via [`MultiProgress::println`].
-#[derive(Debug)]
-struct MultiProgressLineWriter {
-    mp: MultiProgress,
-    buf: Vec<u8>,
-}
-
-impl<'a> MakeWriter<'a> for MultiProgressWriter {
-    type Writer = MultiProgressLineWriter;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        MultiProgressLineWriter {
-            mp: self.mp.clone(),
-            buf: Vec::new(),
-        }
-    }
-}
-
-impl io::Write for MultiProgressLineWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.buf.extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        if !self.buf.is_empty() {
-            let line = String::from_utf8_lossy(&self.buf).trim_end().to_string();
-            self.mp.println(&line)?;
-            self.buf.clear();
-        }
-        Ok(())
-    }
-}
-
-impl Drop for MultiProgressLineWriter {
-    fn drop(&mut self) {
-        let _ = io::Write::flush(self);
-    }
-}
 
 fn main() -> anyhow::Result<()> {
     let multi_progress = MultiProgress::new();
@@ -112,62 +12,11 @@ fn main() -> anyhow::Result<()> {
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
-        .with_writer(MultiProgressWriter {
-            mp: multi_progress.clone(),
-        })
+        .with_writer(MultiProgressWriter::new(multi_progress.clone()))
         .init();
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?
-        .block_on(run(multi_progress))
-}
-
-#[allow(clippy::let_and_return)] // Binding needed to satisfy Rust 2024 tail-expression drop order rules
-#[instrument(skip_all)]
-async fn run(multi_progress: MultiProgress) -> anyhow::Result<()> {
-    let args = Args::parse();
-
-    let ffmpeg_available = ffmpeg::is_available().await;
-
-    if args.embed_existing_subtitles {
-        if !ffmpeg_available {
-            anyhow::bail!(
-                "--embed-existing-subtitles requires ffmpeg, but ffmpeg was not found on PATH"
-            );
-        }
-        ffmpeg::embed_existing_subtitles(&args.directory).await?;
-    }
-
-    let http_client = http_client::http_client();
-    let media = media_resolver::get_media_id(&args.slug).await?;
-
-    if args.fix_existing_subtitles {
-        subtitle_cleaner::fix_existing_subtitles(&args.directory)?;
-    }
-
-    let subtitle_mode = if args.skip_subtitles {
-        SubtitleMode::Skip
-    } else if ffmpeg_available {
-        info!("ffmpeg detected, subtitles will be embedded into video files");
-        SubtitleMode::Embed
-    } else {
-        warn!("ffmpeg not found, subtitles will be downloaded as separate .vtt files");
-        SubtitleMode::Download
-    };
-
-    let params = DownloadParams {
-        http_client,
-        subtitle_mode,
-        concurrent_downloads: args.concurrent_downloads,
-        multi_progress,
-        directory: Arc::from(args.directory.as_str()),
-    };
-
-    let result = match media {
-        MediaType::TvShow(id) => tv_show::download(id, args.start_from_episode, &params).await,
-        MediaType::Movie { id, slug } => movie::download(id, &slug, &params).await,
-    };
-
-    result
+        .block_on(run(CatShowDownloaderArgs::parse(), multi_progress))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI options: show slug, save directory, start episode, concurrent downloads (1–10), skip/fix/embed subtitles.
  * Subtitle handling now detects ffmpeg and chooses embed/download/skip behavior with clear messages.

* **Chores**
  * Released version 1.1.0 and updated changelog.
  * Simplified startup: improved progress and logging integration and consolidated orchestration into a single run workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->